### PR TITLE
chore: :hammer: config settings for working and installing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,21 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"jebbs.plantuml",
+		"donjayamanne.githistory",
+		"felipecaputo.git-project-manager",
+		"GitHub.vscode-pull-request-github",
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"njpwerner.autodocstring",
+		"quarto.quarto",
+		"streetsidesoftware.code-spell-checker",
+		"vivaxy.vscode-conventional-commits",
+		"charliermarsh.ruff",
+		"pshaddel.conventional-branch"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+  "files.autoSave": "onFocusChange",
+  "editor.wordWrap": "off",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always"
+  },
+  "git.autofetch": false,
+  "quarto.visualEditor.markdownWrap": "column",
+  "quarto.visualEditor.markdownWrapColumn": 72,
+  "autoDocstring.customTemplatePath": ".vscode/google-notypes.mustache",
+  "editor.tabCompletion": "on",
+  "editor.snippetSuggestions": "inline",
+  "conventional-branch.type": [
+    "build", // Changes that affect the build system or external dependencies
+    "ci", // Changes to our CI configuration files and scripts
+    "docs", // Documentation only changes
+    "feat", // A new feature
+    "fix", // A bug fix
+    "refactor", // A code change that neither fixes a bug nor adds a feature
+    "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+    "test", // Adding missing tests or correcting existing tests
+    "chore", // Misc things, like renaming or deleting files
+  ],
+  "conventional-branch.format": "{Type}/{Branch}",
+  "[quarto][qmd]": {
+    "editor.formatOnSave": false
+  },
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "python.languageServer": "Pylance",
+  "files.insertFinalNewline": true,
+  "cSpell.enableFiletypes": [
+    "quarto"
+  ],
+  "cSpell.language": "en,en-GB",
+}

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ export PATH=$HOME/.local/bin:$PATH
 
 Close your terminal and re-run `echo $PATH` to check that it worked.
 
-You now have installed the spaid helper functions!
+If it worked and you now see the folder, you have installed the spaid helper functions!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
-# spaid
+# spaid: Seedcase Project aid --- a toolkit for developing Seedcase
 
-Seedcase Project aid: A toolkit for developing Seedcase
+## Installation
+
+Clone this repo to somewhere on your computer. Then open a terminal in
+the newly created folder and run:
+
+``` bash
+just install
+```
+
+After that is finished, check to make sure that the `~/.local/bin`
+folder is on your execution path (so your Terminal can find the
+installed commands) by running:
+
+``` bash
+echo $PATH
+```
+
+Review the output and if there is somewhere that looks like:
+
+```         
+.local/bin:
+```
+
+Then you don't need to do anything else. If you don't see that folder,
+find your `~/.zshrc`, open it in a text editor, and add this line to
+that file:
+
+``` bash
+export PATH=$HOME/.local/bin:$PATH
+```
+
+Close your terminal and re-run `echo $PATH` to check that it worked.
+
+You now have installed the spaid helper functions!

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ folder is on your execution path (so your Terminal can find the
 installed commands) by running:
 
 ``` bash
-echo $PATH
+echo $PATH | grep -o "\.local/bin"
 ```
 
-Review the output and if there is somewhere that looks like:
+The output should give this:
 
 ```         
 .local/bin:
@@ -31,6 +31,6 @@ that file:
 export PATH=$HOME/.local/bin:$PATH
 ```
 
-Close your terminal and re-run `echo $PATH` to check that it worked.
+Close your terminal and re-run the code to check that it worked.
 
 If it worked and you now see the folder, you have installed the spaid helper functions!

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+@_default:
+    just --list --unsorted
+
+# Install all scripts in `bin/` to `~/.local/bin/`
+install:
+    mkdir -p ~/.local/bin
+    ln -s $(pwd)/bin/* ~/.local/bin


### PR DESCRIPTION
## Description

This starts setting up the repo to be able to add scripts that are stored in `~/.local/bin` location, which is a common location to store executables. I included some installation instructions, let me know how they work out!

Closes #4

<!-- Please delete as appropriate: -->
This PR needs a fairly short review.
