### PR TITLE
fix: :bug: need to use `shift` after assigning org and repo

### DIFF
--- a/bin/spaid_pr_merge_rebase
+++ b/bin/spaid_pr_merge_rebase
@@ -23,9 +23,10 @@ if [[ "$1" == "-h" ]] ; then
     exit 0
 fi
 
+org="$1"
+repo="$2"
 # Shifts are needed to get all numbers at the end.
-org="$1"; shift
-repo="$2"; shift
+shift 2
 # Set as an array with `()`.
 pr_numbers=("$@")
 


### PR DESCRIPTION
## Description

`shift` needs to be used after assigning and needs to shift the arg numbers over by 2 in order for the `$@` to work.

<!-- Select quick/in-depth as necessary -->
Doesn't need a PR.

## Checklist

- [x] Ran `just run-all`
