### PR TITLE
chore: :truck: add `src/` to `py_file` after sprout refactor

### DIFF
--- a/bin/spaid_create_python_files
+++ b/bin/spaid_create_python_files
@@ -30,7 +30,7 @@ then
     exit 1
 fi
 
-py_file=$(pwd)/$1/$2/$3.py
+py_file=$(pwd)/src/$1/$2/$3.py
 test_file=$(pwd)/tests/$2/test_$3.py
 touch $py_file $test_file
 


### PR DESCRIPTION
## Description

When using this command in `sprout` we currently get an error bc the directory (without `src/`) doesn’t exist.
This PR fixes that by updating the `py_file` path to include `src/`

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
