### PR TITLE
fix: :bug: can't use backticks in help docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,6 @@ Positional arguments:
 spaid_gh_set_repo_settings -h
 ```
 
-/home/luke/.local/bin/spaid_gh_set_repo_settings:3: command not found:
-main
-
 Usage: spaid_gh_set_repo_settings \[<org>\] \[<repo>\] \[-h\]
 
 Set up a repository with our Seedcase Project defaults. Settings used
@@ -209,7 +206,7 @@ are:
 - Omit the wiki.
 - Disable discussions.
 - Allow PR’s to have an option to auto-merge after approval.
-- Allow PR’s to have an option to easily update with the branch.
+- Allow PR’s to have an option to easily update with the ‘main’ branch.
 - Allow merge commits as well as rebase and squash merges.
 
 Examples:

--- a/bin/spaid_gh_set_repo_settings
+++ b/bin/spaid_gh_set_repo_settings
@@ -9,7 +9,7 @@ Set up a repository with our Seedcase Project defaults. Settings used are:
 - Omit the wiki.
 - Disable discussions.
 - Allow PR's to have an option to auto-merge after approval.
-- Allow PR's to have an option to easily update with the `main` branch.
+- Allow PR's to have an option to easily update with the 'main' branch.
 - Allow merge commits as well as rebase and squash merges.
 
 Examples:


### PR DESCRIPTION
## Description

\` can't be used in shell strings, as they tells shell to run a command at that location. Shell strings aren't designed to write Markdown.

No review needed. 

## Checklist

- [x] Ran `just run-all`
