### PR TITLE
fix: :bug: add error message when no organisation is given

### DIFF
--- a/bin/spaid_pr_merge_chores
+++ b/bin/spaid_pr_merge_chores
@@ -27,6 +27,11 @@ fi
 org="$1"
 repo="$2"
 
+if [[ "$org" == "" ]] ; then
+    echo "Error: No organization has been given. Please provide one."
+    exit 1
+fi
+
 chores=$(gh search prs \
     --archived=false \
     --owner "$org" \


### PR DESCRIPTION
# Description

Otherwise, when no organisation is given as input, the command doesn't show that is was missing and that nothing was done.
The message is almost identical to the message in the `merge_rebase` command.

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
