### PR TITLE
feat: :sparkles: add `build(deps-dev): bump` to `spaid_pr_merge_chores`

### DIFF
--- a/bin/spaid_pr_merge_chores
+++ b/bin/spaid_pr_merge_chores
@@ -39,7 +39,7 @@ chores=$(gh search prs \
     --state open \
     --limit 100 \
     --json title,repository,number \
-    --jq 'map(select(.title | contains("chore(sync):") or contains("ci(pre-commit):") or contains("synced file(s)") or contains("ci(deps)") or contains("build(deps): bump")))'
+    --jq 'map(select(.title | contains("chore(sync):") or contains("ci(pre-commit):") or contains("synced file(s)") or contains("ci(deps)") or contains("build(deps): bump") or contains("build(deps-dev): bump")))'
 )
 
 echo $chores |


### PR DESCRIPTION
# Description

I'm not exactly sure when and how we started having this scope (`deps-dev`) but this includes it in `pr_merge_chores`.

E.g., seedcase-project/seedcase-sprout#1629 and seedcase-project/seedcase-sprout#1630

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
