### PR TITLE
refactor: :recycle: only chore merge from known bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,10 @@ spaid_pr_merge_chores -h
 
 Usage: spaid_pr_merge_chores \[-h\]
 
-Go through all open PRs in a GitHub organization (or optionally in only
-one repo) and do a merge rebase on them if they contain the string
-‘chore(sync):’, ‘ci(pre-commit):’, ‘ci(deps)’, or ‘build(deps): bump’ in
-the title. Requires admin privilege, so not everyone can use this
-command.
+Go through all open PRs in a GitHub organization and do a rebase merge
+on them if they start with the string ‘ci’ or ‘build’ in the title and
+if the author is either ‘dependabot\[bot\]’ or ‘pre-commit-ci\[bot\]’.
+Requires admin privilege to run.
 
 Examples:
 
@@ -127,9 +126,6 @@ Examples:
 Positional arguments:
 
 - org: Required. The name of the GitHub organization.
-- repo: Optional. The name of the repository in the GitHub organization.
-  If not given, the command will run on all repositories in the
-  organization.
 
 ### GitHub organization management (invitations, teams)
 

--- a/bin/spaid_pr_merge_chores
+++ b/bin/spaid_pr_merge_chores
@@ -3,10 +3,9 @@
 help_text="
 Usage: `basename $0` [-h]
 
-Go through all open PRs in a GitHub organization (or optionally in only one repo)
-and do a merge rebase on them if they contain the string 'chore(sync):',
-'ci(pre-commit):', 'ci(deps)', or 'build(deps): bump' in the title.
-Requires admin privilege, so not everyone can use this command.
+Go through all open PRs in a GitHub organization and do a rebase merge on them
+if they start with the string 'ci' or 'build' in the title and if the author is
+either 'dependabot[bot]' or 'pre-commit-ci[bot]'. Requires admin privilege to run.
 
 Examples:
 
@@ -15,8 +14,6 @@ Examples:
 Positional arguments:
 
 - org: Required. The name of the GitHub organization.
-- repo: Optional. The name of the repository in the GitHub organization.
-  If not given, the command will run on all repositories in the organization.
 "
 
 if [[ "$1" == "-h" ]] ; then
@@ -25,7 +22,6 @@ if [[ "$1" == "-h" ]] ; then
 fi
 
 org="$1"
-repo="$2"
 
 if [[ "$org" == "" ]] ; then
     echo "Error: No organization has been given. Please provide one."
@@ -35,11 +31,12 @@ fi
 chores=$(gh search prs \
     --archived=false \
     --owner "$org" \
-    --repo "$repo" \
     --state open \
     --limit 100 \
+    --author "dependabot[bot]" \
+    --author "pre-commit-ci[bot]" \
     --json title,repository,number \
-    --jq 'map(select(.title | startswith("chore(sync):") or startswith("ci(pre-commit):") or startswith("synced file(s)") or startswith("ci(deps)") or startswith("build(deps): bump") or startswith("build(deps-dev): bump")))'
+    --jq 'map(select(.title | startswith("ci") or startswith("build")))'
 )
 
 echo $chores |


### PR DESCRIPTION
## Description

To help with security, only merge PRs from pre-commit-ci bot and dependabot.

This PR needs no review.

## Checklist

- [x] Ran `just run-all`
