### PR TITLE
refactor: ♻️ only do squash merges, don't allow anything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,26 +85,26 @@ Positional argument:
 
 - org: The name of the GitHub organization.
 
-#### `spaid_pr_merge_rebase`
+#### `spaid_pr_merge_squash`
 
 ``` bash
-spaid_pr_merge_rebase -h
+spaid_pr_merge_squash -h
 ```
 
-Usage: spaid_pr_merge_rebase \[-h\]
+Usage: spaid_pr_merge_squash \[-h\]
 
-Approve and do a merge rebase on one PRs in a single repository.
+Approve and do a squash merge on one PRs in a single repository.
 Requires admin privilege, so not everyone can use this command.
 
 Examples:
 
-    # Do merge rebase on (fake) PRs 1, 2, and 3.
+    # Do squash merge on (fake) PRs 1, 2, and 3.
     spaid_pr_merge_rebase seedcase-project seedcase-theme 1 2 3
 
 Positional arguments:
 
 - repo_spec: The GitHub repository spec, in the format of ‘owner/repo’.
-- PR number: A PR number to do the merge rebase for.
+- PR number: A PR number to do the squash merge for.
 
 #### `spaid_pr_merge_chores`
 
@@ -114,7 +114,7 @@ spaid_pr_merge_chores -h
 
 Usage: spaid_pr_merge_chores \[-h\]
 
-Go through all open PRs in a GitHub organization and do a rebase merge
+Go through all open PRs in a GitHub organization and do a squash merge
 on them if they start with the string ‘ci’ or ‘build’ in the title and
 if the author is either ‘dependabot\[bot\]’ or ‘pre-commit-ci\[bot\]’.
 Requires admin privilege to run.
@@ -364,7 +364,8 @@ are:
 - Omit the wiki.
 - Disable discussions.
 - Allow PR’s to have an option to auto-merge after approval.
-- Allow merge commits as well as rebase and squash merges.
+- Allow only squash merges and use the PR title and description as the
+  squash commit message.
 - Allow PR branch updates from ‘main’.
 
 Examples:

--- a/README.qmd
+++ b/README.qmd
@@ -67,11 +67,11 @@ commands at once. A note is given below the relevant commands for how.
 spaid_pr_list -h
 ```
 
-#### `spaid_pr_merge_rebase`
+#### `spaid_pr_merge_squash`
 
 ```{bash}
 #| output: asis
-spaid_pr_merge_rebase -h
+spaid_pr_merge_squash -h
 ```
 
 #### `spaid_pr_merge_chores`

--- a/bin/spaid_gh_ruleset_require_pr
+++ b/bin/spaid_gh_ruleset_require_pr
@@ -72,8 +72,7 @@ require_pr() {
             "require_last_push_approval": true,
             "required_review_thread_resolution": true,
             "allowed_merge_methods": [
-              "squash",
-              "rebase"
+              "squash"
             ]
           }
         }

--- a/bin/spaid_gh_set_repo_settings
+++ b/bin/spaid_gh_set_repo_settings
@@ -9,7 +9,7 @@ Set up a repository with our Seedcase Project defaults. Settings used are:
 - Omit the wiki.
 - Disable discussions.
 - Allow PR's to have an option to auto-merge after approval.
-- Allow merge commits as well as rebase and squash merges.
+- Allow only squash merges and use the PR title and description as the squash commit message.
 - Allow PR branch updates from 'main'.
 
 Examples:
@@ -38,7 +38,8 @@ gh repo edit $repo_spec \
   --enable-wiki=false \
   --enable-discussions=false \
   --enable-auto-merge=true \
-  --enable-merge-commit=true \
-  --enable-rebase-merge=true \
+  --enable-merge-commit=false \
+  --enable-rebase-merge=false \
   --enable-squash-merge=true \
+  --squash-merge-commit-message "pr-title-description" \
   --allow-update-branch

--- a/bin/spaid_pr_merge_chores
+++ b/bin/spaid_pr_merge_chores
@@ -3,7 +3,7 @@
 help_text="
 Usage: `basename $0` [-h]
 
-Go through all open PRs in a GitHub organization and do a rebase merge on them
+Go through all open PRs in a GitHub organization and do a squash merge on them
 if they start with the string 'ci' or 'build' in the title and if the author is
 either 'dependabot[bot]' or 'pre-commit-ci[bot]'. Requires admin privilege to run.
 
@@ -44,5 +44,5 @@ echo $chores |
     while read pr; do
         repo=$(echo $pr | jq -r ".repository.name")
         number=$(echo $pr | jq -r ".number")
-        spaid_pr_merge_rebase "$org/$repo" "$number"
+        spaid_pr_merge_squash "$org/$repo" "$number"
     done

--- a/bin/spaid_pr_merge_squash
+++ b/bin/spaid_pr_merge_squash
@@ -3,18 +3,18 @@
 help_text="
 Usage: `basename $0` [-h]
 
-Approve and do a merge rebase on one PRs in a single repository.
+Approve and do a squash merge on one PRs in a single repository.
 Requires admin privilege, so not everyone can use this command.
 
 Examples:
 
-    # Do merge rebase on (fake) PRs 1, 2, and 3.
+    # Do squash merge on (fake) PRs 1, 2, and 3.
     spaid_pr_merge_rebase seedcase-project seedcase-theme 1 2 3
 
 Positional arguments:
 
 - repo_spec: The GitHub repository spec, in the format of 'owner/repo'.
-- PR number: A PR number to do the merge rebase for.
+- PR number: A PR number to do the squash merge for.
 "
 
 if [[ "$1" == "-h" ]] ; then
@@ -52,7 +52,7 @@ merge_pr() {
     gh pr merge \
         --repo "$repo_spec" \
         --admin \
-        --rebase $pr_number
+        --squash $pr_number
 }
 
 approve_pr "$repo_spec" "$pr_number"


### PR DESCRIPTION
# Description

As per a discussion me and @signekb had, we'll only allow squash merges.

Needs no review.

## Checklist

- [x] Ran `just run-all`
