### PR TITLE
fix: 🐛 can only search PRs one author at a time in merge chores

### DIFF
--- a/bin/spaid_pr_merge_chores
+++ b/bin/spaid_pr_merge_chores
@@ -28,16 +28,22 @@ if [[ "$org" == "" ]] ; then
     exit 1
 fi
 
-chores=$(gh search prs \
-    --archived=false \
-    --owner "$org" \
-    --state open \
-    --limit 100 \
-    --author "dependabot[bot]" \
-    --author "pre-commit-ci[bot]" \
-    --json title,repository,number \
-    --jq 'map(select(.title | startswith("ci") or startswith("build")))'
-)
+search_prs() {
+  local author="$1"
+  gh search prs \
+      --archived=false \
+      --owner "$org" \
+      --state open \
+      --limit 100 \
+      --author "$author" \
+      --json title,repository,number \
+      --jq 'map(select(.title | startswith("ci") or startswith("build")))'
+}
+
+# Can only search for one author at a time, so we have to do it twice
+# and combine the results.
+chores=$(search_prs "dependabot[bot]")
+chores+=$(search_prs "pre-commit-ci[bot]")
 
 echo $chores |
     jq -c '.[]' |


### PR DESCRIPTION
# Description

GitHub might have made a change in how search works, but on the CLI, you can only search for one author at a time. So this splits it up to find the two bots we use.

This PR needs no review.

## Checklist

-  [x] Ran `just run-all`
